### PR TITLE
fix: Use LINODE_TOKEN in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Package
+        env:
+          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
         run: make
 
       - name: Upload Release Asset


### PR DESCRIPTION
This pull requests explicitly specifies `LINODE_TOKEN` as an environment variable for `make` in `release.yml`. This allows tests to successfully run during the release process.