### PR TITLE
fix: Add retry logic to k8s requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/google/uuid v1.1.1
-	github.com/linode/linodego v1.3.0
+	github.com/linode/linodego v1.4.1
 	github.com/linode/linodego/k8s v0.0.0-20201007210559-5fa0a6ce0187
 	github.com/rancher/kontainer-engine v0.0.4-dev.0.20201016211542-bb3014a09ff1
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20190329191031-25c5027a8c7b/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v0.7.3-0.20190808172531-150530564a14/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
@@ -243,6 +244,7 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
@@ -356,10 +358,13 @@ github.com/leanovate/gopter v0.2.4/go.mod h1:gNcbPWNEWRe4lm+bycKqxUYoH5uoVje5SkO
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.0/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
+github.com/linode/linodego v0.20.1/go.mod h1:XOWXRHjqeU2uPS84tKLgfWIfTlv3TYzCS0io4GOQzEI=
 github.com/linode/linodego v1.1.0 h1:ZiFVUptlzuExtUbHZtXiN7I0dAOFQAyirBKb/6/n9n4=
 github.com/linode/linodego v1.1.0/go.mod h1:x/7+BoaKd4unViBmS2umdjYyVAmpFtBtEXZ0wou7FYQ=
 github.com/linode/linodego v1.3.0 h1:77BPapuzhfIhXodiDUt/M76H46UiFYOytEupVN2auDI=
 github.com/linode/linodego v1.3.0/go.mod h1:PVsRxSlOiJyvG4/scTszpmZDTdgS+to3X6eS8pRrWI8=
+github.com/linode/linodego v1.4.1 h1:cgpY1jCZ47wfJvWH5V8in7Tphj8T0sR1URiH9e6G2bA=
+github.com/linode/linodego v1.4.1/go.mod h1:PVsRxSlOiJyvG4/scTszpmZDTdgS+to3X6eS8pRrWI8=
 github.com/linode/linodego/k8s v0.0.0-20201007210559-5fa0a6ce0187 h1:BD3B4omCTwJmYMXY8dOlmuDBDVAAMn8F+BabglL3HvU=
 github.com/linode/linodego/k8s v0.0.0-20201007210559-5fa0a6ce0187/go.mod h1:MWI0tFyaJqRpirMv0VO7CGYT4V3IhHvml2rs/DlRQmY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=

--- a/vendor/github.com/linode/linodego/Makefile
+++ b/vendor/github.com/linode/linodego/Makefile
@@ -8,6 +8,8 @@ GOLANGCILINT      := golangci-lint
 GOLANGCILINT_IMG  := golangci/golangci-lint:v1.38-alpine
 GOLANGCILINT_ARGS := run
 
+LINODE_URL := https://api.linode.com/
+
 PACKAGES := $(shell go list ./... | grep -v integration)
 
 SKIP_LINT ?= 0
@@ -50,6 +52,7 @@ run_fixtures:
 	LINODE_FIXTURE_MODE="record" \
 	LINODE_TOKEN=$(LINODE_TOKEN) \
 	LINODE_API_VERSION="v4beta" \
+	LINODE_URL="$(LINODE_URL)" \
 	GO111MODULE="on" \
 	go test -timeout=60m -v $(ARGS)
 

--- a/vendor/github.com/linode/linodego/account_events.go
+++ b/vendor/github.com/linode/linodego/account_events.go
@@ -62,6 +62,12 @@ const (
 	ActionCommunityQuestionReply   EventAction = "community_question_reply"
 	ActionCommunityLike            EventAction = "community_like"
 	ActionCreateCardUpdated        EventAction = "credit_card_updated"
+	ActionDatabaseCreate           EventAction = "database_create"
+	ActionDatabaseDelete           EventAction = "database_delete"
+	ActionDatabaseUpdate           EventAction = "database_update"
+	ActionDatabaseUpdateFailed     EventAction = "database_update_failed"
+	ActionDatabaseBackupRestore    EventAction = "database_backup_restore"
+	ActionDatabaseCredentialsReset EventAction = "database_credentials_reset"
 	ActionDiskCreate               EventAction = "disk_create"
 	ActionDiskDelete               EventAction = "disk_delete"
 	ActionDiskUpdate               EventAction = "disk_update"
@@ -147,6 +153,7 @@ type EntityType string
 const (
 	EntityLinode       EntityType = "linode"
 	EntityDisk         EntityType = "disk"
+	EntityDatabase     EntityType = "database"
 	EntityDomain       EntityType = "domain"
 	EntityFirewall     EntityType = "firewall"
 	EntityNodebalancer EntityType = "nodebalancer"
@@ -169,10 +176,11 @@ const (
 // can be used to access it.
 type EventEntity struct {
 	// ID may be a string or int, it depends on the EntityType
-	ID    interface{} `json:"id"`
-	Label string      `json:"label"`
-	Type  EntityType  `json:"type"`
-	URL   string      `json:"url"`
+	ID     interface{} `json:"id"`
+	Label  string      `json:"label"`
+	Type   EntityType  `json:"type"`
+	Status string      `json:"status"`
+	URL    string      `json:"url"`
 }
 
 // EventsPagedResponse represents a paginated Events API response

--- a/vendor/github.com/linode/linodego/client.go
+++ b/vendor/github.com/linode/linodego/client.go
@@ -54,6 +54,7 @@ type Client struct {
 
 	Account                *Resource
 	AccountSettings        *Resource
+	Databases              *Resource
 	DomainRecords          *Resource
 	Domains                *Resource
 	Events                 *Resource
@@ -86,6 +87,7 @@ type Client struct {
 	LongviewClients          *Resource
 	LongviewSubscriptions    *Resource
 	Managed                  *Resource
+	DatabaseMySQLInstances   *Resource
 	NodeBalancerConfigs      *Resource
 	NodeBalancerNodes        *Resource
 	NodeBalancerStats        *Resource
@@ -215,6 +217,12 @@ func (c *Client) SetRetries() *Client {
 	return c
 }
 
+// AddRetryCondition adds a RetryConditional function to the Client
+func (c *Client) AddRetryCondition(retryCondition RetryConditional) *Client {
+	c.resty.AddRetryCondition(resty.RetryConditionFunc(retryCondition))
+	return c
+}
+
 func (c *Client) addRetryConditional(retryConditional RetryConditional) *Client {
 	c.retryConditionals = append(c.retryConditionals, retryConditional)
 	return c
@@ -276,13 +284,12 @@ func NewClient(hc *http.Client) (client Client) {
 
 	if baseURLExists {
 		client.SetBaseURL(baseURL)
+	}
+	apiVersion, apiVersionExists := os.LookupEnv(APIVersionVar)
+	if apiVersionExists {
+		client.SetAPIVersion(apiVersion)
 	} else {
-		apiVersion, apiVersionExists := os.LookupEnv(APIVersionVar)
-		if apiVersionExists {
-			client.SetAPIVersion(apiVersion)
-		} else {
-			client.SetAPIVersion(APIVersion)
-		}
+		client.SetAPIVersion(APIVersion)
 	}
 
 	certPath, certPathExists := os.LookupEnv(APIHostCert)
@@ -316,6 +323,7 @@ func addResources(client *Client) {
 	resources := map[string]*Resource{
 		accountName:                  NewResource(client, accountName, accountEndpoint, false, Account{}, nil),                         // really?
 		accountSettingsName:          NewResource(client, accountSettingsName, accountSettingsEndpoint, false, AccountSettings{}, nil), // really?
+		databasesName:                NewResource(client, databasesName, databasesEndpoint, false, Database{}, nil),
 		domainRecordsName:            NewResource(client, domainRecordsName, domainRecordsEndpoint, true, DomainRecord{}, DomainRecordsPagedResponse{}),
 		domainsName:                  NewResource(client, domainsName, domainsEndpoint, false, Domain{}, DomainsPagedResponse{}),
 		eventsName:                   NewResource(client, eventsName, eventsEndpoint, false, Event{}, EventsPagedResponse{}),
@@ -345,6 +353,7 @@ func addResources(client *Client) {
 		longviewclientsName:          NewResource(client, longviewclientsName, longviewclientsEndpoint, false, LongviewClient{}, LongviewClientsPagedResponse{}),
 		longviewsubscriptionsName:    NewResource(client, longviewsubscriptionsName, longviewsubscriptionsEndpoint, false, LongviewSubscription{}, LongviewSubscriptionsPagedResponse{}),
 		managedName:                  NewResource(client, managedName, managedEndpoint, false, nil, nil), // really?
+		mysqlName:                    NewResource(client, mysqlName, mysqlEndpoint, false, Database{}, nil),
 		nodebalancerconfigsName:      NewResource(client, nodebalancerconfigsName, nodebalancerconfigsEndpoint, true, NodeBalancerConfig{}, NodeBalancerConfigsPagedResponse{}),
 		nodebalancernodesName:        NewResource(client, nodebalancernodesName, nodebalancernodesEndpoint, true, NodeBalancerNode{}, NodeBalancerNodesPagedResponse{}),
 		nodebalancerStatsName:        NewResource(client, nodebalancerStatsName, nodebalancerStatsEndpoint, true, NodeBalancerStats{}, nil),
@@ -373,6 +382,7 @@ func addResources(client *Client) {
 	client.resources = resources
 
 	client.Account = resources[accountName]
+	client.Databases = resources[databasesName]
 	client.DomainRecords = resources[domainRecordsName]
 	client.Domains = resources[domainsName]
 	client.Events = resources[eventsName]
@@ -400,6 +410,7 @@ func addResources(client *Client) {
 	client.Longview = resources[longviewName]
 	client.LongviewSubscriptions = resources[longviewsubscriptionsName]
 	client.Managed = resources[managedName]
+	client.DatabaseMySQLInstances = resources[mysqlName]
 	client.NodeBalancerConfigs = resources[nodebalancerconfigsName]
 	client.NodeBalancerNodes = resources[nodebalancernodesName]
 	client.NodeBalancerStats = resources[nodebalancerStatsName]

--- a/vendor/github.com/linode/linodego/databases.go
+++ b/vendor/github.com/linode/linodego/databases.go
@@ -1,0 +1,210 @@
+package linodego
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/linode/linodego/internal/parseabletime"
+)
+
+type DatabasesPagedResponse struct {
+	*PageOptions
+	Data []Database `json:"data"`
+}
+
+func (DatabasesPagedResponse) endpoint(c *Client) string {
+	endpoint, err := c.Databases.Endpoint()
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%s/instances", endpoint)
+}
+
+func (resp *DatabasesPagedResponse) appendData(r *DatabasesPagedResponse) {
+	resp.Data = append(resp.Data, r.Data...)
+}
+
+type DatabaseEnginesPagedResponse struct {
+	*PageOptions
+	Data []DatabaseEngine `json:"data"`
+}
+
+func (DatabaseEnginesPagedResponse) endpoint(c *Client) string {
+	endpoint, err := c.Databases.Endpoint()
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%s/engines", endpoint)
+}
+
+func (resp *DatabaseEnginesPagedResponse) appendData(r *DatabaseEnginesPagedResponse) {
+	resp.Data = append(resp.Data, r.Data...)
+}
+
+type DatabaseTypesPagedResponse struct {
+	*PageOptions
+	Data []DatabaseType `json:"data"`
+}
+
+func (DatabaseTypesPagedResponse) endpoint(c *Client) string {
+	endpoint, err := c.Databases.Endpoint()
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%s/types", endpoint)
+}
+
+func (resp *DatabaseTypesPagedResponse) appendData(r *DatabaseTypesPagedResponse) {
+	resp.Data = append(resp.Data, r.Data...)
+}
+
+// A Database is a instance of Linode Managed Databases
+type Database struct {
+	ID              int          `json:"id"`
+	Status          string       `json:"status"`
+	Label           string       `json:"label"`
+	Hosts           DatabaseHost `json:"hosts"`
+	Region          string       `json:"region"`
+	Type            string       `json:"type"`
+	Engine          string       `json:"engine"`
+	Version         string       `json:"version"`
+	ClusterSize     int          `json:"cluster_size"`
+	ReplicationType string       `json:"replication_type"`
+	SSLConnection   bool         `json:"ssl_connection"`
+	Encrypted       bool         `json:"encrypted"`
+	AllowList       []string     `json:"allow_list"`
+	InstanceURI     string       `json:"instance_uri"`
+	Created         *time.Time   `json:"-"`
+	Updated         *time.Time   `json:"-"`
+}
+
+// DatabaseHost for Primary/Secondary of Database
+type DatabaseHost struct {
+	Primary   string `json:"primary"`
+	Secondary string `json:"secondary,omitempty"`
+}
+
+// DatabaseEngine is information about Engines supported by Linode Managed Databases
+type DatabaseEngine struct {
+	ID      string `json:"id"`
+	Engine  string `json:"engine"`
+	Version string `json:"version"`
+}
+
+// DatabaseType is information about the supported Database Types by Linode Managed Databases
+type DatabaseType struct {
+	ID          string            `json:"id"`
+	Label       string            `json:"label"`
+	Class       string            `json:"class"`
+	Deprecated  bool              `json:"deprecated"`
+	VirtualCPUs int               `json:"vcpus"`
+	Disk        int               `json:"disk"`
+	Memory      int               `json:"memory"`
+	ClusterSize []DatabaseCluster `json:"cluster_size"`
+}
+
+// DatabaseCluster Sizes and Prices
+type DatabaseCluster struct {
+	Quantity int          `json:"quantity"`
+	Price    ClusterPrice `json:"price"`
+}
+
+// ClusterPrice for Hourly and Monthly price models
+type ClusterPrice struct {
+	Hourly  float32 `json:"hourly"`
+	Monthly float32 `json:"monthly"`
+}
+
+func (d *Database) UnmarshalJSON(b []byte) error {
+	type Mask Database
+
+	p := struct {
+		*Mask
+		Created *parseabletime.ParseableTime `json:"created"`
+		Updated *parseabletime.ParseableTime `json:"updated"`
+	}{
+		Mask: (*Mask)(d),
+	}
+
+	if err := json.Unmarshal(b, &p); err != nil {
+		return err
+	}
+
+	d.Created = (*time.Time)(p.Created)
+	d.Updated = (*time.Time)(p.Updated)
+	return nil
+}
+
+// ListDatabases lists all Database instances in Linode Managed Databases for the account
+func (c *Client) ListDatabases(ctx context.Context, opts *ListOptions) ([]Database, error) {
+	response := DatabasesPagedResponse{}
+
+	err := c.listHelper(ctx, &response, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Data, nil
+}
+
+// ListDatabaseEngines lists all Database Engines
+func (c *Client) ListDatabaseEngines(ctx context.Context, opts *ListOptions) ([]DatabaseEngine, error) {
+	response := DatabaseEnginesPagedResponse{}
+
+	err := c.listHelper(ctx, &response, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Data, nil
+}
+
+// GetDatabaseEngine returns a specific Database Engine
+func (c *Client) GetDatabaseEngine(ctx context.Context, opts *ListOptions, id string) (*DatabaseEngine, error) {
+	e, err := c.Databases.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R(ctx)
+
+	e = fmt.Sprintf("%s/engines/%s", e, id)
+	r, err := coupleAPIErrors(req.SetResult(&DatabaseEngine{}).Get(e))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Result().(*DatabaseEngine), nil
+}
+
+// ListDatabaseTypes lists all Types of Database provided in Linode Managed Databases
+func (c *Client) ListDatabaseTypes(ctx context.Context, opts *ListOptions) ([]DatabaseType, error) {
+	response := DatabaseTypesPagedResponse{}
+
+	err := c.listHelper(ctx, &response, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Data, nil
+}
+
+// GetDatabaseType returns a specific Database Type
+func (c *Client) GetDatabaseType(ctx context.Context, opts *ListOptions, id string) (*DatabaseType, error) {
+	e, err := c.Databases.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R(ctx)
+
+	e = fmt.Sprintf("%s/types/%s", e, id)
+	r, err := coupleAPIErrors(req.SetResult(&DatabaseType{}).Get(e))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Result().(*DatabaseType), nil
+}

--- a/vendor/github.com/linode/linodego/instance_ips.go
+++ b/vendor/github.com/linode/linodego/instance_ips.go
@@ -35,9 +35,9 @@ type InstanceIP struct {
 
 // InstanceIPv6Response contains the IPv6 addresses and ranges for an Instance
 type InstanceIPv6Response struct {
-	LinkLocal *InstanceIP  `json:"link_local"`
-	SLAAC     *InstanceIP  `json:"slaac"`
-	Global    []*IPv6Range `json:"global"`
+	LinkLocal *InstanceIP `json:"link_local"`
+	SLAAC     *InstanceIP `json:"slaac"`
+	Global    []IPv6Range `json:"global"`
 }
 
 // IPv6Range represents a range of IPv6 addresses routed to a single Linode in a given Region

--- a/vendor/github.com/linode/linodego/lke_clusters.go
+++ b/vendor/github.com/linode/linodego/lke_clusters.go
@@ -59,6 +59,11 @@ type LKEClusterKubeconfig struct {
 	KubeConfig string `json:"kubeconfig"`
 }
 
+// LKEClusterDashboard fields are those returned by GetLKEClusterDashboard
+type LKEClusterDashboard struct {
+	URL string `json:"url"`
+}
+
 // LKEClusterControlPlane fields contained within the `control_plane` attribute of an LKE cluster.
 type LKEClusterControlPlane struct {
 	HighAvailability bool `json:"high_availability"`
@@ -280,6 +285,20 @@ func (c *Client) GetLKEClusterKubeconfig(ctx context.Context, id int) (*LKEClust
 		return nil, err
 	}
 	return r.Result().(*LKEClusterKubeconfig), nil
+}
+
+// GetLKEClusterDashboard gets information about the dashboard for an LKE cluster
+func (c *Client) GetLKEClusterDashboard(ctx context.Context, id int) (*LKEClusterDashboard, error) {
+	e, err := c.LKEClusters.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	e = fmt.Sprintf("%s/%d/dashboard", e, id)
+	r, err := coupleAPIErrors(c.R(ctx).SetResult(&LKEClusterDashboard{}).Get(e))
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*LKEClusterDashboard), nil
 }
 
 // RecycleLKEClusterNodes recycles all nodes in all pools of the specified LKE Cluster.

--- a/vendor/github.com/linode/linodego/mysql.go
+++ b/vendor/github.com/linode/linodego/mysql.go
@@ -1,0 +1,334 @@
+package linodego
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/linode/linodego/internal/parseabletime"
+)
+
+// A MySQLDatabase is a instance of Linode MySQL Managed Databases
+type MySQLDatabase struct {
+	ID              int          `json:"id"`
+	Status          string       `json:"status"`
+	Label           string       `json:"label"`
+	Hosts           DatabaseHost `json:"hosts"`
+	Region          string       `json:"region"`
+	Type            string       `json:"type"`
+	Engine          string       `json:"engine"`
+	Version         string       `json:"version"`
+	ClusterSize     int          `json:"cluster_size"`
+	ReplicationType string       `json:"replication_type"`
+	SSLConnection   bool         `json:"ssl_connection"`
+	Encrypted       bool         `json:"encrypted"`
+	AllowList       []string     `json:"allow_list"`
+	InstanceURI     string       `json:"instance_uri"`
+	Created         *time.Time   `json:"-"`
+	Updated         *time.Time   `json:"-"`
+}
+
+func (d *MySQLDatabase) UnmarshalJSON(b []byte) error {
+	type Mask MySQLDatabase
+
+	p := struct {
+		*Mask
+		Created *parseabletime.ParseableTime `json:"created"`
+		Updated *parseabletime.ParseableTime `json:"updated"`
+	}{
+		Mask: (*Mask)(d),
+	}
+
+	if err := json.Unmarshal(b, &p); err != nil {
+		return err
+	}
+
+	d.Created = (*time.Time)(p.Created)
+	d.Updated = (*time.Time)(p.Updated)
+	return nil
+}
+
+// MySQLCreateOptions fields are used when creating a new MySQL Database
+type MySQLCreateOptions struct {
+	AllowList       []string `json:"allow_list"`
+	Label           string   `json:"label"`
+	Region          string   `json:"region"`
+	Type            string   `json:"type"`
+	Engine          string   `json:"engine"`
+	ReplicationType string   `json:"replication_type"`
+	ClusterSize     int      `json:"cluster_size"`
+	Encrypted       bool     `json:"encrypted"`
+	SSLConnection   bool     `json:"ssl_connection"`
+}
+
+// MySQLUpdateOptions fields are used when altering the existing MySQL Database
+type MySQLUpdateOptions struct {
+	Label     string   `json:"label,omitempty"`
+	AllowList []string `json:"allow_list,omitempty"`
+}
+
+// MySQLDatabaseBackup is information for interacting with a backup for the existing MySQL Database
+type MySQLDatabaseBackup struct {
+	ID      int        `json:"id"`
+	Label   string     `json:"label"`
+	Type    string     `json:"type"`
+	Created *time.Time `json:"-"`
+}
+
+func (d *MySQLDatabaseBackup) UnmarshalJSON(b []byte) error {
+	type Mask MySQLDatabaseBackup
+
+	p := struct {
+		*Mask
+		Created *parseabletime.ParseableTime `json:"created"`
+	}{
+		Mask: (*Mask)(d),
+	}
+
+	if err := json.Unmarshal(b, &p); err != nil {
+		return err
+	}
+
+	d.Created = (*time.Time)(p.Created)
+	return nil
+}
+
+type MySQLDatabasesPagedResponse struct {
+	*PageOptions
+	Data []MySQLDatabase `json:"data"`
+}
+
+func (MySQLDatabasesPagedResponse) endpoint(c *Client) string {
+	endpoint, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		panic(err)
+	}
+	return endpoint
+}
+
+func (resp *MySQLDatabasesPagedResponse) appendData(r *MySQLDatabasesPagedResponse) {
+	resp.Data = append(resp.Data, r.Data...)
+}
+
+// MySQLDatabaseCredential is the Root Credentials to access the Linode Managed Database
+type MySQLDatabaseCredential struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// MySQLDatabaseSSL is the SSL Certificate to access the Linode Managed MySQL Database
+type MySQLDatabaseSSL struct {
+	CACertificate []byte `json:"ca_certificate"`
+}
+
+// ListMySQLDatabase lists all MySQL Databases associated with the account
+func (c *Client) ListMySQLDatabases(ctx context.Context, opts *ListOptions) ([]MySQLDatabase, error) {
+	response := MySQLDatabasesPagedResponse{}
+
+	err := c.listHelper(ctx, &response, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Data, nil
+}
+
+type MySQLDatabaseBackupsPagedResponse struct {
+	*PageOptions
+	Data []MySQLDatabaseBackup `json:"data"`
+}
+
+func (MySQLDatabaseBackupsPagedResponse) endpointWithID(c *Client, id int) string {
+	endpoint, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%s/%d/backups", endpoint, id)
+}
+
+func (resp *MySQLDatabaseBackupsPagedResponse) appendData(r *MySQLDatabaseBackupsPagedResponse) {
+	resp.Data = append(resp.Data, r.Data...)
+}
+
+// ListMySQLDatabaseBackups lists all MySQL Database Backups associated with the given MySQL Database
+func (c *Client) ListMySQLDatabaseBackups(ctx context.Context, databaseID int, opts *ListOptions) ([]MySQLDatabaseBackup, error) {
+	response := MySQLDatabaseBackupsPagedResponse{}
+
+	err := c.listHelperWithID(ctx, &response, databaseID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Data, nil
+}
+
+// GetMySQLDatabase returns a single MySQL Database matching the id
+func (c *Client) GetMySQLDatabase(ctx context.Context, id int) (*MySQLDatabase, error) {
+	e, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R(ctx)
+
+	e = fmt.Sprintf("%s/%d", e, id)
+	r, err := coupleAPIErrors(req.SetResult(&MySQLDatabase{}).Get(e))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Result().(*MySQLDatabase), nil
+}
+
+// CreateMySQLDatabase creates a new MySQL Database using the createOpts as configuration, returns the new MySQL Database
+func (c *Client) CreateMySQLDatabase(ctx context.Context, createOpts MySQLCreateOptions) (*MySQLDatabase, error) {
+	var body string
+	e, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R(ctx).SetResult(&MySQLDatabase{})
+
+	if bodyData, err := json.Marshal(createOpts); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
+		SetBody(body).
+		Post(e))
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*MySQLDatabase), nil
+}
+
+// DeleteMySQLDatabase deletes an existing MySQL Database with the given id
+func (c *Client) DeleteMySQLDatabase(ctx context.Context, id int) error {
+	e, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		return err
+	}
+
+	req := c.R(ctx)
+
+	e = fmt.Sprintf("%s/%d", e, id)
+	_, err = coupleAPIErrors(req.Delete(e))
+	return err
+}
+
+// UpdateMySQLDatabase updates the given MySQL Database with the provided opts, returns the MySQLDatabase with the new settings
+func (c *Client) UpdateMySQLDatabase(ctx context.Context, id int, opts MySQLUpdateOptions) (*MySQLDatabase, error) {
+	e, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	req := c.R(ctx).SetResult(&MySQLDatabase{})
+
+	bodyData, err := json.Marshal(opts)
+	if err != nil {
+		return nil, NewError(err)
+	}
+
+	body := string(bodyData)
+
+	e = fmt.Sprintf("%s/%d", e, id)
+	r, err := coupleAPIErrors(req.SetBody(body).Put(e))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Result().(*MySQLDatabase), nil
+}
+
+// GetMySQLDatabaseSSL returns the SSL Certificate for the given MySQL Database
+func (c *Client) GetMySQLDatabaseSSL(ctx context.Context, id int) (*MySQLDatabaseSSL, error) {
+	e, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R(ctx)
+
+	e = fmt.Sprintf("%s/%d/ssl", e, id)
+	r, err := coupleAPIErrors(req.SetResult(&MySQLDatabaseSSL{}).Get(e))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Result().(*MySQLDatabaseSSL), nil
+}
+
+// GetMySQLDatabaseCredentials returns the Root Credentials for the given MySQL Database
+func (c *Client) GetMySQLDatabaseCredentials(ctx context.Context, id int) (*MySQLDatabaseCredential, error) {
+	e, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R(ctx)
+
+	e = fmt.Sprintf("%s/%d/credentials", e, id)
+	r, err := coupleAPIErrors(req.SetResult(&MySQLDatabaseCredential{}).Get(e))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Result().(*MySQLDatabaseCredential), nil
+}
+
+// ResetMySQLDatabaseCredentials returns the Root Credentials for the given MySQL Database (may take a few seconds to work)
+func (c *Client) ResetMySQLDatabaseCredentials(ctx context.Context, id int) error {
+	e, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		return err
+	}
+
+	req := c.R(ctx)
+
+	e = fmt.Sprintf("%s/%d/credentials/reset", e, id)
+	_, err = coupleAPIErrors(req.Post(e))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetMySQLDatabaseBackup returns a specific MySQL Database Backup with the given ids
+func (c *Client) GetMySQLDatabaseBackup(ctx context.Context, databaseID int, backupID int) (*MySQLDatabaseBackup, error) {
+	e, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R(ctx)
+
+	e = fmt.Sprintf("%s/%d/backups/%d", e, databaseID, backupID)
+	r, err := coupleAPIErrors(req.SetResult(&MySQLDatabaseBackup{}).Get(e))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Result().(*MySQLDatabaseBackup), nil
+}
+
+// RestoreMySQLDatabaseBackup returns the given MySQL Database with the given Backup
+func (c *Client) RestoreMySQLDatabaseBackup(ctx context.Context, databaseID int, backupID int) error {
+	e, err := c.DatabaseMySQLInstances.Endpoint()
+	if err != nil {
+		return err
+	}
+
+	req := c.R(ctx)
+
+	e = fmt.Sprintf("%s/%d/backups/%d/restore", e, databaseID, backupID)
+	_, err = coupleAPIErrors(req.Post(e))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/linode/linodego/pagination.go
+++ b/vendor/github.com/linode/linodego/pagination.go
@@ -109,6 +109,30 @@ func (c *Client) listHelper(ctx context.Context, i interface{}, opts *ListOption
 			results = r.Result().(*VolumesPagedResponse).Results
 			v.appendData(r.Result().(*VolumesPagedResponse))
 		}
+	case *DatabasesPagedResponse:
+		if r, err = coupleAPIErrors(req.SetResult(DatabasesPagedResponse{}).Get(v.endpoint(c))); err == nil {
+			pages = r.Result().(*DatabasesPagedResponse).Pages
+			results = r.Result().(*DatabasesPagedResponse).Results
+			v.appendData(r.Result().(*DatabasesPagedResponse))
+		}
+	case *DatabaseEnginesPagedResponse:
+		if r, err = coupleAPIErrors(req.SetResult(DatabaseEnginesPagedResponse{}).Get(v.endpoint(c))); err == nil {
+			pages = r.Result().(*DatabaseEnginesPagedResponse).Pages
+			results = r.Result().(*DatabaseEnginesPagedResponse).Results
+			v.appendData(r.Result().(*DatabaseEnginesPagedResponse))
+		}
+	case *DatabaseTypesPagedResponse:
+		if r, err = coupleAPIErrors(req.SetResult(DatabaseTypesPagedResponse{}).Get(v.endpoint(c))); err == nil {
+			pages = r.Result().(*DatabaseTypesPagedResponse).Pages
+			results = r.Result().(*DatabaseTypesPagedResponse).Results
+			v.appendData(r.Result().(*DatabaseTypesPagedResponse))
+		}
+	case *MySQLDatabasesPagedResponse:
+		if r, err = coupleAPIErrors(req.SetResult(MySQLDatabasesPagedResponse{}).Get(v.endpoint(c))); err == nil {
+			pages = r.Result().(*MySQLDatabasesPagedResponse).Pages
+			results = r.Result().(*MySQLDatabasesPagedResponse).Results
+			v.appendData(r.Result().(*MySQLDatabasesPagedResponse))
+		}
 	case *DomainsPagedResponse:
 		if r, err = coupleAPIErrors(req.SetResult(DomainsPagedResponse{}).Get(v.endpoint(c))); err == nil {
 			response, ok := r.Result().(*DomainsPagedResponse)
@@ -376,6 +400,12 @@ func (c *Client) listHelperWithID(ctx context.Context, i interface{}, idRaw inte
 			pages = r.Result().(*LKENodePoolsPagedResponse).Pages
 			results = r.Result().(*LKENodePoolsPagedResponse).Results
 			v.appendData(r.Result().(*LKENodePoolsPagedResponse))
+		}
+	case *MySQLDatabaseBackupsPagedResponse:
+		if r, err = coupleAPIErrors(req.SetResult(MySQLDatabaseBackupsPagedResponse{}).Get(v.endpointWithID(c, id))); err == nil {
+			pages = r.Result().(*MySQLDatabaseBackupsPagedResponse).Pages
+			results = r.Result().(*MySQLDatabaseBackupsPagedResponse).Results
+			v.appendData(r.Result().(*MySQLDatabaseBackupsPagedResponse))
 		}
 	case *NodeBalancerConfigsPagedResponse:
 		if r, err = coupleAPIErrors(req.SetResult(NodeBalancerConfigsPagedResponse{}).Get(v.endpointWithID(c, id))); err == nil {

--- a/vendor/github.com/linode/linodego/resources.go
+++ b/vendor/github.com/linode/linodego/resources.go
@@ -12,6 +12,7 @@ import (
 const (
 	accountName                  = "account"
 	accountSettingsName          = "accountsettings"
+	databasesName                = "databases"
 	domainRecordsName            = "records"
 	domainsName                  = "domains"
 	eventsName                   = "events"
@@ -41,6 +42,7 @@ const (
 	longviewclientsName          = "longviewclients"
 	longviewsubscriptionsName    = "longviewsubscriptions"
 	managedName                  = "managed"
+	mysqlName                    = "mysql"
 	nodebalancerconfigsName      = "nodebalancerconfigs"
 	nodebalancernodesName        = "nodebalancernodes"
 	nodebalancerStatsName        = "nodebalancerstats"
@@ -67,6 +69,7 @@ const (
 
 	accountEndpoint                = "account"
 	accountSettingsEndpoint        = "account/settings"
+	databasesEndpoint              = "databases"
 	domainRecordsEndpoint          = "domains/{{ .ID }}/records"
 	domainsEndpoint                = "domains"
 	eventsEndpoint                 = "account/events"
@@ -96,6 +99,7 @@ const (
 	longviewclientsEndpoint        = "longview/clients"
 	longviewsubscriptionsEndpoint  = "longview/subscriptions"
 	managedEndpoint                = "managed"
+	mysqlEndpoint                  = "databases/mysql/instances"
 	// @TODO we can't use these nodebalancer endpoints unless we include these templated fields
 	// The API seems inconsistent about including parent IDs in objects, (compare instance configs to nb configs)
 	// Parent IDs would be immutable for updates and are ignored in create requests ..

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,7 +36,7 @@ github.com/json-iterator/go
 # github.com/konsorten/go-windows-terminal-sequences v1.0.2
 ## explicit
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/linode/linodego v1.3.0
+# github.com/linode/linodego v1.4.1
 ## explicit; go 1.16
 github.com/linode/linodego
 github.com/linode/linodego/internal/duration


### PR DESCRIPTION
This pull request enables retries on `WaitForLKEClusterConditions` and `generateServiceAccountToken`. This should significantly reduce the number of intermittent LKE cluster provisioning errors in Rancher.

Integration tests are consistently passing.