### PR TITLE
new: Add support for configuring HA control planes 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ trash-keep: .dapper
 
 deps: trash
 
+test:
+	go test $(TEST_ARGS) -timeout 25m
+
 .DEFAULT_GOAL := ci
 
 .PHONY: $(TARGETS)

--- a/linode_driver_test.go
+++ b/linode_driver_test.go
@@ -5,6 +5,7 @@ import (
 	raw "github.com/linode/linodego"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -14,12 +15,11 @@ import (
 )
 
 func TestDriver(t *testing.T) {
-	name := strings.Replace(uuid.New().String(), "-", "", -1)
+	t.Parallel()
 
-	token := os.Getenv("LINODE_TOKEN")
-	if token == "" {
-		t.Fatal("missing Linode token")
-	}
+	name := generateResourceName()
+
+	token := getLinodeToken(t)
 
 	d := &Driver{}
 	client, err := d.getServiceClient(context.TODO(), token)
@@ -27,20 +27,7 @@ func TestDriver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lkeVersions, err := client.ListLKEVersions(context.TODO(), &raw.ListOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	lkeVersionsStr := make([]string, len(lkeVersions))
-	for i, v := range lkeVersions {
-		lkeVersionsStr[i] = v.ID
-	}
-
-	sort.Strings(lkeVersionsStr)
-
-	// We should be testing on the latest version
-	kubernetesVersion := lkeVersionsStr[len(lkeVersionsStr)-1]
+	kubernetesVersion := getLatestK8sVersion(t, client)
 
 	opts := types.DriverOptions{
 		BoolOptions: nil,
@@ -83,6 +70,8 @@ func TestDriver(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	validateLKEClusterProperties(t, client, info, false)
+
 	v, err := d.GetVersion(context.Background(), info)
 	if err != nil {
 		t.Fatal(err)
@@ -120,9 +109,217 @@ func TestDriver(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	validateLKEClusterProperties(t, client, info, false)
+
 	uc, err := d.GetClusterSize(context.Background(), info)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, int64(3), uc.Count, "Cluster size")
+}
+
+func TestDriver_HighAvailability(t *testing.T) {
+	t.Parallel()
+
+	name := generateResourceName()
+
+	token := getLinodeToken(t)
+
+	d := &Driver{}
+	client, err := d.getServiceClient(context.TODO(), token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kubernetesVersion := getLatestK8sVersion(t, client)
+
+	opts := types.DriverOptions{
+		BoolOptions: map[string]bool{
+			"high-availability": true,
+		},
+		StringOptions: map[string]string{
+			"name":               name,
+			"label":              name,
+			"access-token":       token,
+			"region":             "us-west",
+			"kubernetes-version": kubernetesVersion,
+		},
+		StringSliceOptions: map[string]*types.StringSlice{
+			"tags": {
+				Value: []string{
+					"rancher",
+					"lke",
+					"test",
+				},
+			},
+			"node-pools": {
+				Value: []string{
+					"g6-standard-1=2",
+				},
+			},
+		},
+	}
+	info, err := d.Create(context.Background(), &opts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err = d.Remove(context.Background(), info)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	info, err = d.PostCheck(context.Background(), info)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validateLKEClusterProperties(t, client, info, true)
+
+	v, err := d.GetVersion(context.Background(), info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, kubernetesVersion, v.Version, "Kubernetes version")
+
+	c, err := d.GetClusterSize(context.Background(), info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, int64(2), c.Count, "Cluster size")
+}
+
+func TestDriver_HighAvailabilityUpgrade(t *testing.T) {
+	t.Parallel()
+
+	name := generateResourceName()
+
+	token := getLinodeToken(t)
+
+	d := &Driver{}
+	client, err := d.getServiceClient(context.TODO(), token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kubernetesVersion := getLatestK8sVersion(t, client)
+
+	opts := types.DriverOptions{
+		BoolOptions: nil,
+		StringOptions: map[string]string{
+			"name":               name,
+			"label":              name,
+			"access-token":       token,
+			"region":             "us-west",
+			"kubernetes-version": kubernetesVersion,
+		},
+		StringSliceOptions: map[string]*types.StringSlice{
+			"tags": {
+				Value: []string{
+					"rancher",
+					"lke",
+					"test",
+				},
+			},
+			"node-pools": {
+				Value: []string{
+					"g6-standard-1=2",
+				},
+			},
+		},
+	}
+	info, err := d.Create(context.Background(), &opts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err = d.Remove(context.Background(), info)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	info, err = d.PostCheck(context.Background(), info)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validateLKEClusterProperties(t, client, info, false)
+
+	info, err = d.Update(context.Background(), info, &types.DriverOptions{
+		BoolOptions: map[string]bool{
+			"high-availability": true,
+		},
+		StringOptions: map[string]string{
+			"name":               name,
+			"label":              name,
+			"access-token":       token,
+			"region":             "us-west",
+			"kubernetes-version": kubernetesVersion,
+		},
+		StringSliceOptions: map[string]*types.StringSlice{
+			"node-pools": {
+				Value: []string{
+					"g6-standard-1=3",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err = d.PostCheck(context.Background(), info)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validateLKEClusterProperties(t, client, info, true)
+}
+
+func validateLKEClusterProperties(t *testing.T, client *raw.Client, info *types.ClusterInfo, ha bool) {
+	clusterId, err := strconv.Atoi(info.Metadata["cluster-id"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	linodeCluster, err := client.GetLKECluster(context.Background(), clusterId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, linodeCluster.ControlPlane.HighAvailability, ha)
+}
+
+func getLatestK8sVersion(t *testing.T, client *raw.Client) string {
+	lkeVersions, err := client.ListLKEVersions(context.TODO(), &raw.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lkeVersionsStr := make([]string, len(lkeVersions))
+	for i, v := range lkeVersions {
+		lkeVersionsStr[i] = v.ID
+	}
+
+	sort.Strings(lkeVersionsStr)
+
+	// We should be testing on the latest version
+	return lkeVersionsStr[len(lkeVersionsStr)-1]
+}
+
+func getLinodeToken(t *testing.T) string {
+	token := os.Getenv("LINODE_TOKEN")
+	if token == "" {
+		t.Fatal("missing Linode token")
+	}
+
+	return token
+}
+
+func generateResourceName() string {
+	return strings.Replace(uuid.New().String(), "-", "", -1)
 }


### PR DESCRIPTION
This pull request adds a `high-availability` driver option for provisioning and upgrading clusters to HA. This has been tested against the Rancher API, but will need a corresponding change on `rancher/ui` to appear in the interface. 