### PR TITLE
ref: Use Makefile in Dapper workflow

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,7 +5,7 @@ ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
 RUN apt-get update && \
-    apt-get install -y gcc ca-certificates git wget curl vim less file && \
+    apt-get install -y gcc ca-certificates git wget curl vim less file make && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 TARGETS := $(shell ls scripts)
 
+TEST_TIMEOUT := 25m
+
 .dapper:
 	@echo Downloading dapper
 	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
@@ -19,7 +21,7 @@ trash-keep: .dapper
 deps: trash
 
 test:
-	go test $(TEST_ARGS) -timeout 25m
+	go test $(TEST_ARGS) -timeout $(TEST_TIMEOUT)
 
 .DEFAULT_GOAL := ci
 

--- a/linode_driver_test.go
+++ b/linode_driver_test.go
@@ -281,12 +281,12 @@ func TestDriver_HighAvailabilityUpgrade(t *testing.T) {
 }
 
 func validateLKEClusterProperties(t *testing.T, client *raw.Client, info *types.ClusterInfo, ha bool) {
-	clusterId, err := strconv.Atoi(info.Metadata["cluster-id"])
+	clusterID, err := strconv.Atoi(info.Metadata["cluster-id"])
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	linodeCluster, err := client.GetLKECluster(context.Background(), clusterId)
+	linodeCluster, err := client.GetLKECluster(context.Background(), clusterID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/test
+++ b/scripts/test
@@ -8,4 +8,4 @@ echo Running tests
 PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
 
 [ "${ARCH}" == "amd64" ] && RACE=-race
-go test ${RACE} -cover -tags=test ${PACKAGES}
+make TEST_ARGS="${RACE} -cover -tags=test ${PACKAGES}" test


### PR DESCRIPTION
This pull request switches the Dapper test script from using a direct `go test` call to using `make test`. This resolves the timeout inconsistencies when running HA cluster tests. 