### PR TITLE
fix: Explicitly create Service Account Token secret

### DIFF
--- a/util.go
+++ b/util.go
@@ -22,7 +22,7 @@ const (
 	clusterAdmin              = "cluster-admin"
 	kontainerEngine           = "kontainer-engine"
 	newClusterRoleBindingName = "system-netes-default-clusterRoleBinding"
-	serviceAccountSecretName  = "cattle-secret"
+	serviceAccountSecretName  = "kontainer-engine-secret"
 )
 
 func generateServiceAccountToken(clientset kubernetes.Interface) (string, error) {
@@ -92,16 +92,12 @@ func generateServiceAccountToken(clientset kubernetes.Interface) (string, error)
 		return "", fmt.Errorf("error creating role bindings: %v", err)
 	}
 
-	if serviceAccount, err = clientset.CoreV1().ServiceAccounts(cattleNamespace).Get(context.TODO(), serviceAccount.Name, metav1.GetOptions{}); err != nil {
-		return "", fmt.Errorf("error getting service account: %v", err)
-	}
-
 	// Create a service account token secret
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: serviceAccountSecretName,
 			Annotations: map[string]string{
-				"kubernetes.io/service-account.name": serviceAccount.Name,
+				"kubernetes.io/service-account.name": kontainerEngine,
 			},
 		},
 		Type: v1.SecretTypeServiceAccountToken,


### PR DESCRIPTION
## 📝 Description

This change updates the `generateServiceAccountToken` to generate its own Service Account Token secret rather than relying on the implicitly generated secret that is created in older Kubernetes versions. This issue caused LKE clusters on both `v1.26` and `v1.27` to fail to provision through Rancher.

## ✔️ How to Test

1. Build `kontainer-engine-driver-lke`

```
CGO_ENABLED=0 GOOS=linux go build
```

2. Upload the resulting binary to an OBJ bucket with public read permissions.
3. Provision a Rancher instance using Docker.

```
sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged --name rancher rancher/rancher
```

4. Configure your Rancher instance.
5. Once your Rancher instance has been configured
    - Navigate to the [Cluster Drivers page](https://localhost/dashboard/c/_/manager/pages/rke-drivers)
    - Expand the menu next to `Linode LKE`
    - Click `Edit`
    - Remove the checksum
    - Add a link to the binary you uploaded to the OBJ bucket (e.g. `https://foobar.us-southeast-1.linodeobjects.com/kontainer-engine-driver-lke`)
    - Click save
    - Activate the driver
 6. Attempt to provision an LKE cluster through Rancher.

If successful, the cluster should be provisioned as normal.
 