### PR TITLE
test: replace legacy regions in test

### DIFF
--- a/linode_driver_test.go
+++ b/linode_driver_test.go
@@ -35,7 +35,7 @@ func TestDriver(t *testing.T) {
 			"name":               name,
 			"label":              name,
 			"access-token":       token,
-			"region":             "us-west",
+			"region":             "us-ord",
 			"kubernetes-version": kubernetesVersion,
 		},
 		StringSliceOptions: map[string]*types.StringSlice{
@@ -89,7 +89,7 @@ func TestDriver(t *testing.T) {
 			"name":               name,
 			"label":              name,
 			"access-token":       token,
-			"region":             "us-west",
+			"region":             "us-ord",
 			"kubernetes-version": kubernetesVersion,
 		},
 		StringSliceOptions: map[string]*types.StringSlice{
@@ -141,7 +141,7 @@ func TestDriver_HighAvailability(t *testing.T) {
 			"name":               name,
 			"label":              name,
 			"access-token":       token,
-			"region":             "us-west",
+			"region":             "us-ord",
 			"kubernetes-version": kubernetesVersion,
 		},
 		StringSliceOptions: map[string]*types.StringSlice{
@@ -212,7 +212,7 @@ func TestDriver_HighAvailabilityUpgrade(t *testing.T) {
 			"name":               name,
 			"label":              name,
 			"access-token":       token,
-			"region":             "us-west",
+			"region":             "us-ord",
 			"kubernetes-version": kubernetesVersion,
 		},
 		StringSliceOptions: map[string]*types.StringSlice{
@@ -257,7 +257,7 @@ func TestDriver_HighAvailabilityUpgrade(t *testing.T) {
 			"name":               name,
 			"label":              name,
 			"access-token":       token,
-			"region":             "us-west",
+			"region":             "us-ord",
 			"kubernetes-version": kubernetesVersion,
 		},
 		StringSliceOptions: map[string]*types.StringSlice{
@@ -283,7 +283,7 @@ func TestDriver_HighAvailabilityUpgrade(t *testing.T) {
 			"name":               name,
 			"label":              name,
 			"access-token":       token,
-			"region":             "us-west",
+			"region":             "us-ord",
 			"kubernetes-version": kubernetesVersion,
 		},
 		StringSliceOptions: map[string]*types.StringSlice{


### PR DESCRIPTION
## 📝 Description

Regions have been updated:
Legacy Compute sites are in Atlanta, Dallas, Frankfurt, Fremont, London, Mumbai, Newark, Singapore, Sydney, Tokyo, and Toronto

New Core Compute sites are in Amsterdam, Chennai, Chicago, Jakarta, Los Angeles, Madrid (coming soon!), Miami, Milan, Osaka, Paris, São Paulo, Seattle, Stockholm, and Washington, DC (and the list will continue to grow).

All integration test runs provision infrastructure only in New Core Compute sites (not Legacy Compute sites). For this repository, replacing all legacy regions with Chicago and Miami region

## ✔️ How to Test

make test 

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**